### PR TITLE
Fix velocity scaling to account for encoder mounting (joint vs motor side)

### DIFF
--- a/CiA402MotionControl/CiA402MotionControl.cpp
+++ b/CiA402MotionControl/CiA402MotionControl.cpp
@@ -777,9 +777,9 @@ struct CiA402MotionControl::Impl
 
     void setSDORefSpeed(int j, double spDegS)
     {
-        // ----  map JOINT deg/s -> LOOP SHAFT deg/s (based on vel loop source + mount) ----
+        // ----  map JOINT deg/s -> LOOP SHAFT deg/s (based on pos loop source + mount) ----
         double shaft_deg_s = spDegS; // default assume joint shaft
-        switch (this->velLoopSrc[j])
+        switch (this->posLoopSrc[j])
         {
         case Impl::SensorSrc::Enc1:
             if (this->enc1Mount[j] == Impl::Mount::Motor)


### PR DESCRIPTION

While performing some smoke tests, I noticed that the measured and desired velocities set via YARP were not coherent with the expected values.

In detail, I realized that [`0x606C`](https://doc.synapticon.com/node/sw5.1/objects_html/6xxx/606c.html?Highlight=0x606c) was reporting the velocity on the **joint side** and not on the **motor side** (as wrongly expected). Similarly, the desired value [`0x60FF`](http://doc.synapticon.com/node/sw5.1/objects_html/6xxx/60ff.html?Highlight=0x60ff) for the velocity control loop and [`0x6081`](https://doc.synapticon.com/node/sw5.1/objects_html/6xxx/6081.html?Highlight=0x6081) for the profile velocity in position control were expressed with respect to the **joint frame** and not the **motor frame**, as incorrectly assumed.

Upon further investigation, I discovered that these values depend on which encoder is used for the position control loop. If the encoder for the position control loop is mounted as *encoder 2* (joint side), all values are automatically scaled on the joint side.

This PR fixes the device behavior by considering the encoder mounting configuration, ensuring that both feedback and reference values are correctly scaled.

---

|                         | Before the fix                                                                                                                      | After the fix                                                                                                                        | Note                                                                                                                             |
| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
| Velocity reading        | <img width="1100" height="650" alt="image" src="https://github.com/user-attachments/assets/a4cefd53-9bbc-45ed-9c4f-28b6ea6a7fbe" /> | <img width="1888" height="1066" alt="image" src="https://github.com/user-attachments/assets/12c59127-9395-471c-b3d4-454f58a967d7" /> | Before the fix, the finite difference of the joint position was close to the motor velocity, revealing an error in scaling.      |
| Direct velocity control | <img width="1076" height="635" alt="image" src="https://github.com/user-attachments/assets/cf1a3699-88e1-44ee-adcf-497815f1293d" /> | <img width="1089" height="717" alt="image" src="https://github.com/user-attachments/assets/8bf59714-4d35-47d5-b0fb-89b818aa1ede" />  | Before the fix, the desired velocity was much lower than the actual velocity, showing a wrong computation of the scaling factor. |
| Position control        | <img width="1100" height="720" alt="image" src="https://github.com/user-attachments/assets/9ece4956-f8dc-45fd-97b5-32012214dcba" /> | <img width="1100" height="720" alt="image" src="https://github.com/user-attachments/assets/e1504fcf-f75d-43c7-b546-439a21182079" />  | After the fix, the target velocity during position control (the generated trajectory) is coherent with the measured one.         |
