### PR TITLE
Add simple PID control parameters and configuration to README and XML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,25 @@ export YARP_DATA_DIRS=/path/to/install/share/yarp:$YARP_DATA_DIRS
 ### Configuration ⚙️
 The plugin requires a configuration file defining the EtherCAT network and device parameters. An example can be found at: [`config/robot/template_1_motor/config.xml`](config/robot/template_1_motor/config.xml)
 
-To drive the internal position loop in *simple PID* mode, provide the new parameters:
+To select the drive internal position controller structure, configure:
+
+- `use_simple_pid_mode` — boolean. When `true` the driver sets `0x2002:00 = 1` (Simple PID);
+   when `false` it sets `0x2002:00 = 2` (Cascaded PID).
+
+To program *simple PID* gains (only meaningful when `use_simple_pid_mode=true`), provide:
 
 - `simple_pid_kp_nm_per_deg` — list of joint-side Kp values in Nm/deg
 - `simple_pid_kd_nm_s_per_deg` — list of joint-side Kd values in Nm*s/deg
 
-When both are present the device converts them to the drive units (mNm/inc and mNm*s/inc),
-forces `0x2002:00 = 1`, and writes `0x2012:01..03` with Ki clamped to zero. See
+The two gain keys are optional as a pair: if exactly one of them is provided the driver
+errors out.
+
+When both are present (and `use_simple_pid_mode=true`) the device converts them to the
+drive units (mNm/inc and mNm*s/inc), and writes `0x2012:01..03` with Ki clamped to zero.
+If `use_simple_pid_mode=false`, any `simple_pid_*` keys are ignored (with a warning) to
+avoid programming/printing `0x2012` with the wrong unit interpretation.
+
+See
 [`doc/protocol_map.md`](./doc/protocol_map.md) for the conversion details.
 
 ### Setting Up `yarprobotinterface` 🛠️

--- a/config/robot/template_1_motor/motion_control/all_joint_mc.xml
+++ b/config/robot/template_1_motor/motion_control/all_joint_mc.xml
@@ -16,6 +16,8 @@ BSD-3-Clause license. -->
     <param name="velocity_feedback_motor"> ( "606C" )</param>    
     <param name="position_feedback_joint"> ( "6064" )</param>
     <param name="velocity_feedback_joint"> ( "606C" )</param>
+    <!-- 0x2002 position control strategy: true => 1 (Simple PID), false => 2 (Cascaded PID) -->
+    <param name="use_simple_pid_mode"> true </param>
     <!-- Example simple PID gains provided in joint Nm/deg and Nm*s/deg -->
     <param name="simple_pid_kp_nm_per_deg"> ( 0.6981 )</param>
     <param name="simple_pid_kd_nm_s_per_deg"> ( 0.01745 )</param>

--- a/doc/modes_and_setpoints.md
+++ b/doc/modes_and_setpoints.md
@@ -40,12 +40,18 @@ See protocol_map.md for exact object indices and data types.
 - Unit formulas (counts↔deg, rpm↔deg/s, Nm↔per‑thousand) and gear‑ratio/mount transforms are listed in protocol_map.md and dual_encoder_handling.md.
 
 ## Simple PID gains
+- `use_simple_pid_mode`: when `true` the driver configures `0x2002:00 = 1` (Simple PID);
+  when `false` it configures `0x2002:00 = 2` (Cascaded PID).
 - `simple_pid_kp_nm_per_deg`: joint-side proportional gain list (Nm/deg). Converted to the
   drive’s simple PID units `[mNm/inc]` using the configured encoder source and gear ratio.
 - `simple_pid_kd_nm_s_per_deg`: joint-side derivative gain list (Nm*s/deg). Converted to
   `[mNm*s/inc]` with the same transforms.
-- When both keys are present, the driver forces `0x2002:00 = 1` (simple PID), programs
+- The gain keys are optional as a pair: if exactly one of the two is provided the driver
+  returns an error.
+- When both gain keys are present and `use_simple_pid_mode=true`, the driver programs
   `0x2012:01/03` with the converted gains, and zeroes `0x2012:02` (Ki).
+- When `use_simple_pid_mode=false`, any `simple_pid_*` keys are ignored to avoid applying
+  the simple-PID conversion rules while in cascaded PID structure.
 
 ## Related
 - protocol_map.md — PDO/SDO reference and conversions

--- a/doc/protocol_map.md
+++ b/doc/protocol_map.md
@@ -42,7 +42,7 @@ Notes:
 
 | Name                          | Index:Sub | Type    | Dir.  | Purpose                             | Values/Notes               |
 |-------------------------------|-----------|---------|-------|-------------------------------------|----------------------------|
-| Position control strategy     | 0x2002:00 | UINT16  | Write | Selects position control mode       | `1` = simple PID           |
+| Position control strategy     | 0x2002:00 | UINT16  | Write | Selects position control mode       | `1` = simple PID, `2` = cascaded PID |
 | Position loop source (vendor) | 0x2012:09 | UINT8   | Read  | Which encoder feeds position loop   | 1=Enc1, 2=Enc2             |
 | Simple PID Kp                 | 0x2012:01 | REAL32  | Write | Position P gain                     | Config in Nm/deg → mNm/inc |
 | Simple PID Ki                 | 0x2012:02 | REAL32  | Write | Position I gain                     | Forced to `0.0`            |
@@ -70,6 +70,10 @@ Notes:
 | Nm → 0x6071         | (motorNm / ratedNm) × 1000 (clamped)    |
 | Kp cfg → drive      | Kp[mNm/inc] = (Kp_cfg[Nm/deg] / gearRatio) × 1000 × counts_per_deg |
 | Kd cfg → drive      | Kd[mNm*s/inc] = (Kd_cfg[Nm*s/deg] / gearRatio) × 1000 × counts_per_deg |
+
+Notes:
+- The `0x2012:*` unit interpretation depends on `0x2002:00`. The conversions above apply to
+	the **simple PID** structure (`0x2002:00 = 1`).
 
 See dual_encoder_handling.md for encoder CPR, mounting, and shaft transforms.
 


### PR DESCRIPTION
- Introduced `simple_pid_kp_nm_per_deg` and `simple_pid_kd_nm_s_per_deg` parameters for joint-side PID gains in the configuration XML.
- Updated README to include details on new PID parameters and their conversion to drive units.
- Implemented methods in `CiA402MotionControl` for setting position control strategy and configuring simple PID gains.
- Enhanced documentation on simple PID gains in `modes_and_setpoints.md` and `protocol_map.md`.


On top of #41