### PR TITLE
Add support for maximum joint torque configuration and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,40 @@ export YARP_DATA_DIRS=/path/to/install/share/yarp:$YARP_DATA_DIRS
 ### Configuration ⚙️
 The plugin requires a configuration file defining the EtherCAT network and device parameters. An example can be found at: [`config/robot/template_1_motor/config.xml`](config/robot/template_1_motor/config.xml)
 
+#### Device parameters
+
+The `CiA402MotionControl` device accepts the following parameters.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `ifname` | string | Yes | Network interface name used by SOEM (for example `eth0`). |
+| `num_axes` | int | Yes | Number of controlled axes. |
+| `period` | float | Yes | Driver periodic thread period in seconds. |
+| `enc1_mount` | list(string) | Yes | One item per axis. Allowed values: `motor`, `joint`. |
+| `enc2_mount` | list(string) | Yes | One item per axis. Allowed values: `motor`, `joint`, `none`. |
+| `position_feedback_joint` | list(string) | Yes | One item per axis. Allowed values: `6064`, `enc1`, `enc2`. |
+| `position_feedback_motor` | list(string) | Yes | One item per axis. Allowed values: `6064`, `enc1`, `enc2`. |
+| `velocity_feedback_joint` | list(string) | Yes | One item per axis. Allowed values: `606C`, `enc1`, `enc2`. |
+| `velocity_feedback_motor` | list(string) | Yes | One item per axis. Allowed values: `606C`, `enc1`, `enc2`. |
+| `inverted_motion_sense_direction` | list(bool) | Yes | One flag per axis. If `true`, command and feedback sign are inverted for that axis. |
+| `position_window_deg` | list(double) | Yes | One item per axis. Position reached window in joint degrees (written through `0x6067`). |
+| `timing_window_ms` | list(double) | Yes | One item per axis. Position reached timing window in milliseconds (`0x6068`). |
+| `pos_limit_min_deg` | list(double) | Yes | One item per axis. Joint-side minimum limit in degrees. |
+| `pos_limit_max_deg` | list(double) | Yes | One item per axis. Joint-side maximum limit in degrees. |
+| `use_position_limits_from_config` | list(bool) | Yes | One flag per axis. If `true`, write `0x607D` from config. If `false`, read `0x607D` from drive and use that. |
+| `axes_names` | list(string) | Yes | One name per axis, returned by axis info APIs. |
+| `first_slave` | int | No | First EtherCAT slave index. Default: `1`. |
+| `expected_slave_name` | string | No | Optional expected slave name for sanity checks. |
+| `pdo_timeout_us` | int | No | PDO receive timeout in microseconds. Default: EthercatManager internal default. |
+| `enable_dc` | bool | No | Enable distributed clocks (SYNC0). Default: `true`. |
+| `dc_shift_ns` | int | No | SYNC0 phase shift in nanoseconds. Default: `0`. |
+| `use_simple_pid_mode` | bool | No | If `true`, set `0x2002:00 = 1` (Simple PID). If `false`, set `0x2002:00 = 2` (Cascaded PID). Default: `false`. |
+| `simple_pid_kp_nm_per_deg` | list(double) | No (pair) | Joint-side Kp values in Nm/deg for simple PID mode. Must be provided together with `simple_pid_kd_nm_s_per_deg`. |
+| `simple_pid_kd_nm_s_per_deg` | list(double) | No (pair) | Joint-side Kd values in Nm*s/deg for simple PID mode. Must be provided together with `simple_pid_kp_nm_per_deg`. |
+| `max_torque_joint_nm` | list(double) | No | Optional joint-side maximum torque in Nm. If provided, each value is converted to motor side and written to `0x6072:00` (per-thousand of `0x6076`). If omitted, the value already stored in the drive is used. |
+
+All list parameters must contain exactly `num_axes` elements.
+
 To select the drive internal position controller structure, configure:
 
 - `use_simple_pid_mode` — boolean. When `true` the driver sets `0x2002:00 = 1` (Simple PID);

--- a/config/robot/template_1_motor/motion_control/all_joint_mc.xml
+++ b/config/robot/template_1_motor/motion_control/all_joint_mc.xml
@@ -21,6 +21,8 @@ BSD-3-Clause license. -->
     <!-- Example simple PID gains provided in joint Nm/deg and Nm*s/deg -->
     <param name="simple_pid_kp_nm_per_deg"> ( 0.6981 )</param>
     <param name="simple_pid_kd_nm_s_per_deg"> ( 0.01745 )</param>
+    <!-- Optional: joint-side max torque in Nm, converted and written to 0x6072 -->
+    <param name="max_torque_joint_nm"> ( 17.0 )</param>
     <param name="position_window_deg"> ( 0.1 )</param>
     <param name="timing_window_ms"> ( 100 )</param>
     <param name="pos_limit_min_deg">               (        -23.0       )</param>

--- a/device/CiA402MotionControl/CiA402MotionControl.cpp
+++ b/device/CiA402MotionControl/CiA402MotionControl.cpp
@@ -1050,9 +1050,10 @@ struct CiA402MotionControl::Impl
                 return false;
             }
 
+            constexpr uint16_t maxTorqueAdmissibleValue = 32767; // per SDO definition (0x6072 is uint16_t)
             const double motorNm = jointNm / gearRatio[j];
             const double perThousand = (motorNm / ratedMotorTorqueNm[j]) * 1000.0;
-            const double clamped = std::clamp(perThousand, 0.0, 65535.0);
+            const double clamped = std::clamp(perThousand, 0.0, static_cast<double>(maxTorqueAdmissibleValue));
             const uint16_t maxPerm = static_cast<uint16_t>(std::llround(clamped));
             const int s = firstSlave + static_cast<int>(j);
 

--- a/device/CiA402MotionControl/CiA402MotionControl.cpp
+++ b/device/CiA402MotionControl/CiA402MotionControl.cpp
@@ -1020,7 +1020,7 @@ struct CiA402MotionControl::Impl
         for (size_t j = 0; j < numAxes; ++j)
         {
             const double jointNm = maxJointTorqueNm[j];
-            if (!(jointNm > 0.0))
+            if (jointNm <= 0.0)
             {
                 yCError(CIA402,
                         "%s j=%zu invalid max joint torque %.6f Nm (must be > 0)",

--- a/device/CiA402MotionControl/CiA402MotionControl.cpp
+++ b/device/CiA402MotionControl/CiA402MotionControl.cpp
@@ -1003,6 +1003,83 @@ struct CiA402MotionControl::Impl
         return true;
     }
 
+    bool configureMaxTorqueFromJointNm(const std::vector<double>& maxJointTorqueNm)
+    {
+        constexpr auto logPrefix = "[configureMaxTorqueFromJointNm]";
+
+        if (maxJointTorqueNm.size() != numAxes)
+        {
+            yCError(CIA402,
+                    "%s invalid vector size (%zu), expected %zu",
+                    logPrefix,
+                    maxJointTorqueNm.size(),
+                    numAxes);
+            return false;
+        }
+
+        for (size_t j = 0; j < numAxes; ++j)
+        {
+            const double jointNm = maxJointTorqueNm[j];
+            if (!(jointNm > 0.0))
+            {
+                yCError(CIA402,
+                        "%s j=%zu invalid max joint torque %.6f Nm (must be > 0)",
+                        logPrefix,
+                        j,
+                        jointNm);
+                return false;
+            }
+
+            if (!(gearRatio[j] > 0.0))
+            {
+                yCError(CIA402,
+                        "%s j=%zu invalid gear ratio %.6f",
+                        logPrefix,
+                        j,
+                        gearRatio[j]);
+                return false;
+            }
+
+            if (!(ratedMotorTorqueNm[j] > 0.0))
+            {
+                yCError(CIA402,
+                        "%s j=%zu invalid rated motor torque %.6f Nm",
+                        logPrefix,
+                        j,
+                        ratedMotorTorqueNm[j]);
+                return false;
+            }
+
+            const double motorNm = jointNm / gearRatio[j];
+            const double perThousand = (motorNm / ratedMotorTorqueNm[j]) * 1000.0;
+            const double clamped = std::clamp(perThousand, 0.0, 65535.0);
+            const uint16_t maxPerm = static_cast<uint16_t>(std::llround(clamped));
+            const int s = firstSlave + static_cast<int>(j);
+
+            const auto err = ethercatManager.writeSDO<uint16_t>(s, 0x6072, 0x00, maxPerm);
+            if (err != ::CiA402::EthercatManager::Error::NoError)
+            {
+                yCError(CIA402,
+                        "%s j=%zu failed to write 0x6072:00",
+                        logPrefix,
+                        j);
+                return false;
+            }
+
+            maxMotorTorqueNm[j] = (static_cast<double>(maxPerm) / 1000.0) * ratedMotorTorqueNm[j];
+
+            yCInfo(CIA402,
+                   "%s j=%zu configured 0x6072 to %u permille (joint=%.6f Nm, motor=%.6f Nm)",
+                   logPrefix,
+                   j,
+                   static_cast<unsigned>(maxPerm),
+                   jointNm,
+                   maxMotorTorqueNm[j]);
+        }
+
+        return true;
+    }
+
     void setSDORefSpeed(int j, double spDegS)
     {
         // ----  map JOINT deg/s -> LOOP SHAFT deg/s (based on pos loop source + mount) ----
@@ -2090,6 +2167,7 @@ bool CiA402MotionControl::open(yarp::os::Searchable& cfg)
 
     std::vector<double> positionWindowDeg; // position window for targetReached
     std::vector<double> timingWindowMs; // timing window for targetReached
+    std::vector<double> maxJointTorqueNmFromConfig; // optional max torque on joint side [Nm]
     std::vector<double> simplePidKpNmPerDeg; // optional simple PID gains
     std::vector<double> simplePidKdNmSecPerDeg;
 
@@ -2104,6 +2182,15 @@ bool CiA402MotionControl::open(yarp::os::Searchable& cfg)
         return false;
     if (!extractListOfDoubleFromSearchable(cfg, "timing_window_ms", timingWindowMs))
         return false;
+
+    const bool hasMaxJointTorqueCfg = cfg.check("max_torque_joint_nm");
+    if (hasMaxJointTorqueCfg
+        && !extractListOfDoubleFromSearchable(cfg,
+                                              "max_torque_joint_nm",
+                                              maxJointTorqueNmFromConfig))
+    {
+        return false;
+    }
 
     const bool hasSimplePidKpCfg = cfg.check("simple_pid_kp_nm_per_deg");
     const bool hasSimplePidKdCfg = cfg.check("simple_pid_kd_nm_s_per_deg");
@@ -2362,6 +2449,22 @@ bool CiA402MotionControl::open(yarp::os::Searchable& cfg)
     {
         yCError(CIA402, "%s failed to read torque values from SDO", logPrefix);
         return false;
+    }
+
+    if (hasMaxJointTorqueCfg)
+    {
+        if (!m_impl->configureMaxTorqueFromJointNm(maxJointTorqueNmFromConfig))
+        {
+            yCError(CIA402,
+                    "%s failed to configure max torque (0x6072) from max_torque_joint_nm",
+                    logPrefix);
+            return false;
+        }
+    } else
+    {
+        yCDebug(CIA402,
+                "%s max_torque_joint_nm not provided: using drive 0x6072 values",
+                logPrefix);
     }
 
     // get the current control strategy

--- a/device/CiA402MotionControl/CiA402MotionControl.cpp
+++ b/device/CiA402MotionControl/CiA402MotionControl.cpp
@@ -1030,7 +1030,7 @@ struct CiA402MotionControl::Impl
                 return false;
             }
 
-            if (!(gearRatio[j] > 0.0))
+            if (gearRatio[j] <= 0.0)
             {
                 yCError(CIA402,
                         "%s j=%zu invalid gear ratio %.6f",
@@ -1040,7 +1040,7 @@ struct CiA402MotionControl::Impl
                 return false;
             }
 
-            if (!(ratedMotorTorqueNm[j] > 0.0))
+            if (ratedMotorTorqueNm[j] <= 0.0)
             {
                 yCError(CIA402,
                         "%s j=%zu invalid rated motor torque %.6f Nm",

--- a/doc/modes_and_setpoints.md
+++ b/doc/modes_and_setpoints.md
@@ -29,6 +29,9 @@ See protocol_map.md for exact object indices and data types.
   - setRefTorque() or setRefCurrent() writes the torque target each cycle.
   - Torque path: joint Nm → motor Nm → per‑thousand of rated motor torque.
   - Current path: A → motor Nm via torque constant → per‑thousand.
+  - Optional config key `max_torque_joint_nm` writes `0x6072:00` at startup.
+    Values are specified on the joint side and converted to motor side through
+    gear ratio before converting to per-thousand of `0x6076`.
   - On CST flavor or mode change, set‑points/latches are cleared to avoid stale outputs.
 
 - PP (profile position):

--- a/doc/protocol_map.md
+++ b/doc/protocol_map.md
@@ -52,6 +52,7 @@ Notes:
 | Velocity loop source (vendor) | 0x2011:05 | UINT8   | Read  | Which encoder feeds velocity loop   | 1=Enc1, 2=Enc2             |
 | Gear ratio numerator          | 0x6091:01 | UINT32  | Read  | Motor:Load gear ratio (numerator)   | Defaults to 1               |
 | Gear ratio denominator        | 0x6091:02 | UINT32  | Read  | Motor:Load gear ratio (denominator) | Defaults to 1               |
+| Max torque                    | 0x6072:00 | UINT16  | R/W   | Maximum permissible motor torque     | Per-thousand of `0x6076`     |
 | Profile velocity              | 0x6081:00 | INT32   | R/W   | PP profile parameter                | Units per drive             |
 | Profile acceleration          | 0x6083:00 | INT32   | R/W   | PP profile parameter                | Units per drive             |
 | Rated motor torque            | 0x6076:00 | INT16/* | Read  | Scale for 0x6071                    | Nm, vendor sizing may vary  |
@@ -70,6 +71,7 @@ Notes:
 | rpm → deg/s         | deg/s = rpm × 360 / 60                  |
 | joint ↔ motor shaft | apply gear ratio and mounting sign      |
 | Nm → 0x6071         | (motorNm / ratedNm) × 1000 (clamped)    |
+| joint Nm → 0x6072   | ((jointNm / gearRatio) / ratedNm) × 1000 |
 | Kp cfg → drive      | Kp[mNm/inc] = (Kp_cfg[Nm/deg] / gearRatio) × 1000 × counts_per_deg |
 | Kd cfg → drive      | Kd[mNm*s/inc] = (Kd_cfg[Nm*s/deg] / gearRatio) × 1000 × counts_per_deg |
 


### PR DESCRIPTION
This PR adds the possobility to set the max torque on the motor. To do so the user needs to specify an optional parameter that express the max torque on the joint side. The parameter is optional. If not provided, the one stored in the driver will be used.

 